### PR TITLE
Bump peerDependencies to include more recent stylelint versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest --coverage"
   },
   "peerDependencies": {
-    "stylelint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+    "stylelint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.2",


### PR DESCRIPTION
Greetings Krister! Here's a tiny PR bumping `peerDependencies`. It was making me sad seeing the "incorrect peer dependency" warning in my terminal; this plugin has kept on truckin' through 7 major versions of stylelint and still works fine with the latest version.

Thanks for this plugin and for helping to end the `z-index` wars!