### PR TITLE
update peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test": "jest --coverage"
   },
   "peerDependencies": {
-    "stylelint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+    "stylelint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0 || ^13.0.0"
   },
   "devDependencies": {
     "babel-eslint": "^10.0.2",


### PR DESCRIPTION
extension works fine with v13 of stylelint however NPM warns and in NPM7 will potentiall install the wrong versions.

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#peerdependencies